### PR TITLE
Allow online release notes

### DIFF
--- a/Kaju Admin App/WndAdmin.xojo_window
+++ b/Kaju Admin App/WndAdmin.xojo_window
@@ -3169,7 +3169,12 @@ End
 		Sub Action()
 		  self.Loading = true
 		  
-		  hvReleaseNotesPreview.LoadPage( ControlValue( fldReleaseNotes ).StringValue, new FolderItem )
+		  dim releaseNotes as string = ControlValue( fldReleaseNotes ).StringValue
+		  if releaseNotes.Left( 4 ) = "http" then
+		    hvReleaseNotesPreview.LoadURL( releaseNotes )
+		  else
+		    hvReleaseNotesPreview.LoadPage( releaseNotes, new FolderItem )
+		  end if
 		  
 		  self.Loading = false
 		End Sub

--- a/Kaju Classes/Kaju/KajuException.xojo_code
+++ b/Kaju Classes/Kaju/KajuException.xojo_code
@@ -13,16 +13,19 @@ Inherits RuntimeException
 	#tag Constant, Name = kErrorCantFindLibsFolder, Type = String, Dynamic = True, Default = \"Can\xE2\x80\x99t locate this applications Libs folder.", Scope = Public
 		#Tag Instance, Platform = Any, Language = de, Definition  = \"Kann den Applications Libs Ordner dieser Anwendung nicht finden."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"T\xC3\xA4t\xC3\xA4 ohjelman kirjastotiedostokansiota ei l\xC3\xB6ydy."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Kan dit programma\xE2\x80\x99s Libs folder niet vinden."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorImproperFunction, Type = String, Dynamic = True, Default = \"This function cannot be used on this platform.", Scope = Public
 		#Tag Instance, Platform = Any, Language = de, Definition  = \"Diese Funktion kann auf dieser Platform nicht benutzt werden."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"T\xC3\xA4t\xC3\xA4 funktiota ei voi k\xC3\xA4ytt\xC3\xA4\xC3\xA4 t\xC3\xA4ll\xC3\xA4 alustalla."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Deze functie kan niet worden gebruikt op dit platform."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorMissingUpdateURL, Type = String, Dynamic = True, Default = \"The update URL is missing.", Scope = Public
 		#Tag Instance, Platform = Any, Language = de, Definition  = \"Die Update URL fehlt."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivitys-URL on kateissa."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"De update URL ontbreekt."
 	#tag EndConstant
 
 

--- a/Kaju Classes/KajuLocale.xojo_code
+++ b/Kaju Classes/KajuLocale.xojo_code
@@ -18,6 +18,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"El fichero descargado parece estar da\xC3\xB1ado."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Ladattu tiedosto vaikuttaa vioittuneelta."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Il file scaricato sembra essere corrotto."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Het gedownloade bestand lijkt te zijn beschadigd."
 	#tag EndConstant
 
 	#tag Constant, Name = kBinaryInfoInvalidReason, Type = String, Dynamic = True, Default = \"Binary information is not valid", Scope = Protected
@@ -26,6 +27,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La informaci\xC3\xB3n binaria no es correcta"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Binaari-informaatio ei ole kelvollista"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Le informazioni binarie non sono valide"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Binaire gegevens zijn ongeldig"
 	#tag EndConstant
 
 	#tag Constant, Name = kCancelButton, Type = String, Dynamic = True, Default = \"&Cancel", Scope = Protected
@@ -37,6 +39,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Linux, Language = fi, Definition  = \"&Peruuta"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"&Kumoa"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"&Annulla"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"&Annuleer"
 	#tag EndConstant
 
 	#tag Constant, Name = kCannotSkipVersionsMessage, Type = String, Dynamic = True, Default = \"You cannot skip versions until you have updated to version <<Version>> or beyond.", Scope = Protected
@@ -45,6 +48,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"No se pueden omitir versiones hasta haber actualizado a la versi\xC3\xB3n <<Version>> o superior."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Et voi ohittaa yht\xC3\xA4\xC3\xA4n versioita ennen kuin olet p\xC3\xA4ivitt\xC3\xA4nyt versioon <<Version>> tai sit\xC3\xA4 uudempaan."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Non puoi saltare le versioni fintanto che non hai aggiornato alla versione <<Version>> o superiori."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"U kunt geen versies overslaan totdat u minstens <<Version>> of hoger heeft ge\xC3\xAFnstalleerd."
 	#tag EndConstant
 
 	#tag Constant, Name = kDownloadingMessage, Type = String, Dynamic = True, Default = \"Downloading...", Scope = Protected
@@ -53,6 +57,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Descargando..."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Ladataan\xE2\x80\xA6"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Scaricando\xE2\x80\xA6"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Downloaden\xE2\x80\xA6"
 	#tag EndConstant
 
 	#tag Constant, Name = kDryRunMessage, Type = String, Dynamic = True, Default = \"(Dry run\x2C not really installing)", Scope = Protected
@@ -61,6 +66,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"(Prueba\x2C sin instalaci\xC3\xB3n real)"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"(Testiajo\x2C ei installoida)"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"(Prova\x2C non sto installando veramente)"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"(Test run\x2C geen installatie)"
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorBadUpdateData, Type = String, Dynamic = True, Default = \"The update data cannot be read.", Scope = Protected
@@ -69,6 +75,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La actualizaci\xC3\xB3n no puede ser le\xC3\xADda."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivitystietoja ei voi lukea."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"I dati dell\xE2\x80\x99aggiornamento non possono essere letti."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Update informatie kon niet worden gelezen."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorIncorrectPacketMarker, Type = String, Dynamic = True, Default = \"The update packet signature marker was incorrect.", Scope = Protected
@@ -77,6 +84,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La firma de la actualizaci\xC3\xB3n es incorrecta."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivityspaketin allekirjoitusmerkint\xC3\xA4 ei ollut oikein."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"La firma del pacchetto di aggiornamento non \xC3\xA8 corretta."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"De update handtekening was incorrect."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorIncorrectPacketSignature, Type = String, Dynamic = True, Default = \"The RSA signature of the update packet cannot be verified.", Scope = Protected
@@ -85,6 +93,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Imposible verificar la firma RSA de la actualizaci\xC3\xB3n."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivityspaketin RSA-allekirjoitusta ei voida varmentaa."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"La firma RSA del pacchetto di aggiornamento non pu\xC3\xB2 essere verificata."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"De RSA handtekening van het update pakket kan niet worden geverifieerd."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorNoUpdateData, Type = String, Dynamic = True, Default = \"No update data was available.", Scope = Protected
@@ -93,6 +102,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"No hay actualizaciones disponibles."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivitysdataa ei ole saatavilla."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Nessun dato dell\xE2\x80\x99aggiornamento disponibile."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Er was geen update informatie beschikbaar."
 	#tag EndConstant
 
 	#tag Constant, Name = kErrorOccurredMessage, Type = String, Dynamic = True, Default = \"An error has occurred. Would you like to try again now or later\?", Scope = Protected
@@ -101,6 +111,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Ha ocurrido un error. \xC2\xBFReintentar ahora o m\xC3\xA1s tarde\?"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Tapahtui virhe. Haluatko yritt\xC3\xA4\xC3\xA4 uudelleen nyt vai my\xC3\xB6hemmin\?"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Si \xC3\xA8 verificato un errore. Vuoi riprovare ora o pi\xC3\xB9 tardi\?"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Er is een fout opgetreden. Wilt u het nu of later nog eens proberen\?"
 	#tag EndConstant
 
 	#tag Constant, Name = kGenericErrorMessage, Type = String, Dynamic = True, Default = \"An error has occurred.", Scope = Protected
@@ -109,6 +120,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Ha ocurrido un error."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"On tapahtunut virhe."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Si \xC3\xA8 verificato un errore."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Er is een fout opgetreden."
 	#tag EndConstant
 
 	#tag Constant, Name = kInstallButton, Type = String, Dynamic = True, Default = \"Install Update", Scope = Protected
@@ -117,6 +129,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Instalar"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Asenna"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Installa"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Installeren"
 	#tag EndConstant
 
 	#tag Constant, Name = kLaterButton, Type = String, Dynamic = True, Default = \"Later", Scope = Protected
@@ -125,6 +138,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"M\xC3\xA1s tarde"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"My\xC3\xB6hemmin"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Pi\xC3\xB9 tardi"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Later"
 	#tag EndConstant
 
 	#tag Constant, Name = kMainNotice, Type = String, Dynamic = True, Default = \"A new version of <<AppName>> is available!", Scope = Protected
@@ -133,6 +147,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"\xC2\xA1Hay disponible una nueva versi\xC3\xB3n de <<AppName>>!"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Uusi versio ohjelmasta <<AppName>> on saatavilla!"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Una nuova versione di <<AppName>> \xC3\xA8 disponibile!"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Een nieuwe versie van <<AppName>> is beschikbaar!"
 	#tag EndConstant
 
 	#tag Constant, Name = kMissingAppNameReason, Type = String, Dynamic = True, Default = \"Missing app name", Scope = Protected
@@ -141,6 +156,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"El nombre de la aplicaci\xC3\xB3n no est\xC3\xA1 disponible "
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Nome dell\xE2\x80\x99applicazione non disponibile"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Ohjelman nimi puuttuu"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"App naam ontbreekt"
 	#tag EndConstant
 
 	#tag Constant, Name = kMissingReason, Type = String, Dynamic = True, Default = \"Missing", Scope = Protected
@@ -149,6 +165,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"No disponible"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Puuttuu"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Non disponibile"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Niet beschikbaar"
 	#tag EndConstant
 
 	#tag Constant, Name = kNewVersionMarker, Type = String, Dynamic = False, Default = \"<<NewVersion>>", Scope = Protected
@@ -160,6 +177,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"NO EXISTE INFORMACION DE LA ACTUALIZACION"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"EI P\xC3\x84IVITYSINFORMAATIOTA"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"NESSUN INFORMAZIONE SULL\xE2\x80\x99AGGIORNAMENTO"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"GEEN UPDATE INFORMATIE"
 	#tag EndConstant
 
 	#tag Constant, Name = kPaymentRequiredMessage, Type = String, Dynamic = True, Default = \"This update is not free and will require payment. Proceed anyway\?", Scope = Protected
@@ -168,6 +186,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Esta actualizaci\xC3\xB3n no es gratuita y requerir\xC3\xA1 un pago. \xC2\xBFContinuar\?"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"T\xC3\xA4m\xC3\xA4 on maksullinen p\xC3\xA4ivitys. Jatketaanko kuitenkin\?"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Questo aggiornamento non \xC3\xA8 gratuito e richieder\xC3\xA0 un pagamento. Vuoi proseguire comunque\?"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Deze update is niet gratis en zal betaling vragen\x2C wilt u doorgaan\?"
 	#tag EndConstant
 
 	#tag Constant, Name = kProceedButton, Type = String, Dynamic = True, Default = \"Proceed", Scope = Protected
@@ -176,6 +195,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Continuar"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Jatketaan"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Continua"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Doorgaan"
 	#tag EndConstant
 
 	#tag Constant, Name = kProcessingFileMessage, Type = String, Dynamic = True, Default = \"Processing file...", Scope = Protected
@@ -184,6 +204,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Procesando fichero..."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"K\xC3\xA4sitell\xC3\xA4\xC3\xA4n tiedostoa\xE2\x80\xA6"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Processando il file..."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Bestand verwerken\xE2\x80\xA6"
 	#tag EndConstant
 
 	#tag Constant, Name = kQuitButton, Type = String, Dynamic = True, Default = \"Quit && Install", Scope = Protected
@@ -192,6 +213,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Salir && Instalar"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Sulje ja asenna"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Chiudi && Installa"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Afsluiten && Installeren"
 	#tag EndConstant
 
 	#tag Constant, Name = kReadyMessage, Type = String, Dynamic = True, Default = \"Ready to install", Scope = Protected
@@ -200,6 +222,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Listo para la instalaci\xC3\xB3n"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Valmiina asentamaan"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Pronto per installare"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Klaar om te installeren"
 	#tag EndConstant
 
 	#tag Constant, Name = kReleaseNotesLabel, Type = String, Dynamic = True, Default = \"Release Notes:", Scope = Protected
@@ -208,6 +231,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Notas de informaci\xC3\xB3n: "
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Julkaisutiedot:"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Note di rilascio:"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Update informatie:"
 	#tag EndConstant
 
 	#tag Constant, Name = kRemindMeLaterButton, Type = String, Dynamic = True, Default = \"Remind Me Later", Scope = Protected
@@ -216,6 +240,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Record\xC3\xA1rmelo m\xC3\xA1s tarde"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Muistuta my\xC3\xB6hemmin"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Ricordamelo pi\xC3\xB9 tardi"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Herinner mij later"
 	#tag EndConstant
 
 	#tag Constant, Name = kSecondaryNoticeMultiple, Type = String, Dynamic = True, Default = \"You have version <<ThisVersion>> and there are multiple updates available. Install one\?", Scope = Protected
@@ -224,6 +249,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La versi\xC3\xB3n actual es <<ThisVersion>> y existen actualizaciones. \xC2\xBFInstalar una actualizaci\xC3\xB3n\?"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Sinulla on versio <<ThisVersion>> ja saatavilla on useita p\xC3\xA4ivityksi\xC3\xA4. Asennetaanko joku\?"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"La versione attuale \xC3\xA8 <<ThisVersion>> e ci sono diversi aggiornamenti disponibile. Vuoi installarne uno\?"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"U heeft versie <<ThisVersion>> en er zijn meerdere updates beschikbaar. Wilt u er een installeren\?"
 	#tag EndConstant
 
 	#tag Constant, Name = kSecondaryNoticeOne, Type = String, Dynamic = True, Default = \"You have version <<ThisVersion>>. Would you like to install version <<NewVersion>>\?", Scope = Protected
@@ -232,6 +258,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La versi\xC3\xB3n utilizada actualmente es <<ThisVersion>>. \xC2\xBFActualizar a la versi\xC3\xB3n <<NewVersion>>\?"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Sinulla on versio <<ThisVersion>>. Haluatko asentaa version <<NewVersion>>\?"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Hai la versione <<ThisVersion>>. Vuoi installare la versione <<NewVersion>>\?"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"U heeft versie <<ThisVersion>>. Wilt u versie <<NewVersion>> installeren\?"
 	#tag EndConstant
 
 	#tag Constant, Name = kSkipVersionButton, Type = String, Dynamic = True, Default = \"Skip Version", Scope = Protected
@@ -240,6 +267,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Saltarse esta versi\xC3\xB3n"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Ohita versio"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Salta questa versione"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Versie overslaan"
 	#tag EndConstant
 
 	#tag Constant, Name = kStopButton, Type = String, Dynamic = True, Default = \"Stop", Scope = Protected
@@ -248,6 +276,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Detener"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Seis"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Stop"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Stop"
 	#tag EndConstant
 
 	#tag Constant, Name = kThisApplication, Type = String, Dynamic = True, Default = \"this application", Scope = Protected
@@ -256,6 +285,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"esta aplicaci\xC3\xB3n"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"t\xC3\xA4m\xC3\xA4 ohjelma"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"quest\xE2\x80\x99applicazione"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Dit programma"
 	#tag EndConstant
 
 	#tag Constant, Name = kThisVersionMarker, Type = String, Dynamic = False, Default = \"<<ThisVersion>>", Scope = Protected
@@ -267,6 +297,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La operaci\xC3\xB3n ha excedido el tiempo m\xC3\xA1ximo."
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Toiminto on aikakatkaistu."
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Il tempo massimo per l\xE2\x80\x99operazione richiesta \xC3\xA8 scaduto."
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"De voortgang is geannuleerd vanwege een time-out."
 	#tag EndConstant
 
 	#tag Constant, Name = kTryAgainButton, Type = String, Dynamic = True, Default = \"Try Again", Scope = Protected
@@ -275,6 +306,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Reintentar"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Yrit\xC3\xA4 uudelleen"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Prova ancora"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Probeer opnieuw"
 	#tag EndConstant
 
 	#tag Constant, Name = kTryLaterButton, Type = String, Dynamic = True, Default = \"Try Later", Scope = Protected
@@ -283,6 +315,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Intentar m\xC3\xA1s tarde"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Yrit\xC3\xA4 my\xC3\xB6hemmin"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Prova pi\xC3\xB9 tardi"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Probeer het later opnieuw"
 	#tag EndConstant
 
 	#tag Constant, Name = kVersionMarker, Type = String, Dynamic = False, Default = \"<<Version>>", Scope = Protected
@@ -294,6 +327,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"La versi\xC3\xB3n debe estar en una de las siguientes formas"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Version t\xC3\xA4ytyy olla joku n\xC3\xA4ist\xC3\xA4"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"La versione deve essere in una di queste forme"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Versie moet in een van de volgende formaten worden ingevoerd"
 	#tag EndConstant
 
 	#tag Constant, Name = kVersionsLabel, Type = String, Dynamic = True, Default = \"Available Versions:", Scope = Protected
@@ -302,6 +336,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Versiones disponibles:"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"Saatavana versiot:"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Versioni disponibili:"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Beschikbare versies:"
 	#tag EndConstant
 
 	#tag Constant, Name = kWindowTitle, Type = String, Dynamic = True, Default = \"Update Available", Scope = Protected
@@ -310,6 +345,7 @@ Protected Module KajuLocale
 		#Tag Instance, Platform = Any, Language = es, Definition  = \"Actualizaci\xC3\xB3n disponible"
 		#Tag Instance, Platform = Any, Language = fi, Definition  = \"P\xC3\xA4ivitys saatavilla"
 		#Tag Instance, Platform = Any, Language = it, Definition  = \"Aggiornamento disponibile"
+		#Tag Instance, Platform = Any, Language = nl, Definition  = \"Update beschikbaar"
 	#tag EndConstant
 
 

--- a/Kaju Classes/KajuUpdateWindow.xojo_window
+++ b/Kaju Classes/KajuUpdateWindow.xojo_window
@@ -657,7 +657,11 @@ End
 		  end if
 		  
 		  static tempFile as FolderItem = GetTemporaryFolderItem
-		  hvNotes.LoadPage( source, tempFile )
+		  if source.Left( 4 ) = "http" then
+		    hvNotes.LoadURL( source )
+		  else
+		    hvNotes.LoadPage( source, tempFile )
+		  end if
 		  
 		  #if DebugBuild then
 		    if not tempFile.Exists then


### PR DESCRIPTION
Added a small bit of 'link' recognition to Kaju that will load an online page in the release notes section if the developer gives an 'http' URL.
Allowing online release notes will give developers greater control over how to display their release notes.
Example: http://mariusth.heliohost.org/vimediamanager/updates/0.7a14.html
