### PR TITLE
Uses InnoSetup installer instead of zip file to update on Windows

### DIFF
--- a/Kaju Classes/Kaju.xojo_code
+++ b/Kaju Classes/Kaju.xojo_code
@@ -363,6 +363,79 @@ Protected Module Kaju
 		End Function
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Function XcopySupported() As Boolean
+		  //MyKajuChanges 3
+		  ' This is basically OSIsSupported but moved over from Kaju.UpdateChecker
+		  
+		  // Ensures that the right tools are available on the current OS
+		  
+		  Var errorCode as integer = 0 // Assume it's fine
+		  Var errorMessage as string
+		  
+		  //
+		  // Try more than once, just in case
+		  //
+		  for repeatIndex as integer = 1 to 2
+		    
+		    #if TargetMacOS then
+		      
+		      errorCode = 0 // If this app can run, it has the right tools
+		      errorMessage = ""
+		      
+		    #elseif TargetWindows then
+		      //MyKajuChanges 3a
+		      'Windows does not need xcopy anymore as we are going to run an InnoSetup installer instead
+		      errorCode = 0 // If this app can run, it has the right tools
+		      errorMessage = ""
+		      
+		      'Var sh as new Shell
+		      'sh.TimeOut = 3000
+		      'sh.Execute "XCOPY /?"
+		      'errorCode = sh.ErrorCode
+		      'if errorCode <> 0 then
+		      'errorMessage = sh.Result.Trim
+		      'end if
+		      //EndOfChanges
+		      
+		    #else // Linux
+		      
+		      Var cmds() as string = array( "rsync --version", "/usr/bin/logger --version" )
+		      
+		      Var sh as new shell
+		      for each cmd as string in cmds
+		        sh.Execute cmd
+		        errorCode = sh.ErrorCode
+		        
+		        if errorCode <> 0 then
+		          errorMessage = "(" + cmd + ") " + sh.Result.Trim
+		          exit for cmd
+		        end if
+		      next
+		      
+		    #endif
+		    
+		    if errorCode = 0 then
+		      exit for repeatIndex
+		    else
+		      errorMessage = errorMessage.Trim
+		      System.Log System.LogLevelCritical, _
+		      CurrentMethodName + ": Tool not available, code " + str( errorCode ) + _
+		      if( errorMessage <> "", ": " + errorMessage, "" )
+		      
+		      'Added notification to user if there is a problem
+		      Var msg As String
+		      msg = "Error. Unable to download and install the update, the necessary tools are not available. "
+		      msg = msg + "Error code: " + Str(errorCode) + ". Error message: " + errorMessage + ". "
+		      msg = msg + " Please see the website FAQ for troubleshooting."
+		      MessageBox(msg)
+		    end if
+		  next
+		  
+		  return errorCode = 0
+		End Function
+	#tag EndMethod
+
 
 	#tag Note, Name = License
 		
@@ -427,6 +500,7 @@ Protected Module Kaju
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -434,18 +508,23 @@ Protected Module Kaju
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -453,6 +532,7 @@ Protected Module Kaju
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Module

--- a/Kaju Classes/Kaju/UpdateChecker.xojo_code
+++ b/Kaju Classes/Kaju/UpdateChecker.xojo_code
@@ -383,34 +383,37 @@ Protected Class UpdateChecker
 		  //
 		  LastError = nil
 		  
-		  //
-		  // Make sure the OS is supported
-		  //
-		  if not OSIsSupported() then
-		    mResult = ResultType.UnsupportedOS
-		    return false
-		  end if
-		  
-		  //
-		  // Check for write permission
-		  //
-		  if true then // Scope
-		    
-		    dim executable as FolderItem = Kaju.TrueExecutableFile
-		    
-		    #if TargetMacOS then
-		      if not executable.Parent.IsWriteable or not Kaju.IsWriteableRecursive( executable ) then
-		        mResult = ResultType.NoWritePermission
-		        return false
-		      end if
-		    #else
-		      if not Kaju.IsWriteableRecursive( executable.Parent ) then
-		        mResult = ResultType.NoWritePermission
-		        return false
-		      end if
-		    #endif
-		    
-		  end if
+		  //MyKajuChanges 1
+		  ' Moved these check to KajuUpdateWindow.HandleOKButton, otherwise may silently fail -> won't check for update
+		  '//
+		  '// Make sure the OS is supported
+		  '//
+		  'if not OSIsSupported() then
+		  'mResult = ResultType.UnsupportedOS
+		  'return false
+		  'end if
+		  '
+		  '//
+		  '// Check for write permission
+		  '//
+		  'if true then // Scope
+		  '
+		  'dim executable as FolderItem = Kaju.TrueExecutableFile
+		  '
+		  '#if TargetMacOS then
+		  'if not executable.Parent.IsWriteable or not Kaju.IsWriteableRecursive( executable ) then
+		  'mResult = ResultType.NoWritePermission
+		  'return false
+		  'end if
+		  '#else
+		  'if not Kaju.IsWriteableRecursive( executable.Parent ) then
+		  'mResult = ResultType.NoWritePermission
+		  'return false
+		  'end if
+		  '#endif
+		  '
+		  'end if
+		  //EndofChanges
 		  
 		  mDryRun = false
 		  
@@ -822,44 +825,59 @@ Protected Class UpdateChecker
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Allow32bitTo64bitUpdates"
+			Visible=false
 			Group="Behavior"
 			InitialValue="True"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="AllowedInteraction"
+			Visible=false
 			Group="Behavior"
 			InitialValue="kAllowAll"
 			Type="UInt32"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="AllowedStage"
+			Visible=false
 			Group="Behavior"
 			InitialValue="App.Development"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="AllowRedirection"
+			Visible=false
 			Group="Behavior"
 			InitialValue="False"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="DefaultImage"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Picture"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="DefaultUseTransparency"
+			Visible=false
 			Group="Behavior"
 			InitialValue="True"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="HonorIgnored"
+			Visible=false
 			Group="Behavior"
 			InitialValue="True"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Index"
@@ -867,6 +885,7 @@ Protected Class UpdateChecker
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -874,22 +893,29 @@ Protected Class UpdateChecker
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="QuitOnCancelIfRequired"
+			Visible=false
 			Group="Behavior"
 			InitialValue="True"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="ServerPublicRSAKey"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -897,7 +923,9 @@ Protected Class UpdateChecker
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Top"
@@ -905,21 +933,29 @@ Protected Class UpdateChecker
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="UpdateURL"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="String"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="UpdateWindowIsOpen"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Result"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="ResultType"
 			EditorType="Enum"
 			#tag EnumValues

--- a/Kaju Update Installer.iss
+++ b/Kaju Update Installer.iss
@@ -1,0 +1,192 @@
+; Sample script for creating an installer for a 64-bit Xojo desktop app
+; The created installer can be used for new installations and also for Kaju updates
+
+#define XojoAppName "MyApp"
+#define MyAppURL "https://mywebsite.com/"
+#define AppGUID "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+#define MyAppVersion GetFileVersion(AddBackslash(SourcePath) + "MyApp.exe")
+#define MyAppPublisher "My Company Name"
+#define MyAppExeName "{#XojoAppName}.exe"
+
+[Setup]
+; NOTE: The value of AppId uniquely identifies this application.
+; Do not use the same AppId value in installers for other applications.
+VersionInfoVersion=1.0.0.0
+SetupLogging=yes
+SignTool=signtool
+SignedUninstaller=yes
+AppId={{#AppGUID}
+AppName={#XojoAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#XojoAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={commonpf}\{#XojoAppName}
+; Since no icons will be created in "{group}", we don't need the wizard
+; to ask for a Start Menu folder name:
+DisableProgramGroupPage=yes
+AllowNoIcons=yes
+LicenseFile=C:\path\to\{#XojoAppName} End User License Agreement.rtf
+OutputDir=.
+OutputBaseFilename=Setup{#XojoAppName}v{#MyAppVersion}_Win64
+Compression=lzma
+SolidCompression=yes
+ChangesAssociations=yes
+ArchitecturesInstallIn64BitMode=x64
+; Require Windows 7 SP1 or later
+MinVersion=6.1.7601
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+; These directories will be created by the installer inside the DefaultDirName
+; (defined above).
+[Dirs]
+Name: "{app}\{#XojoAppName} Libs"
+Name: "{app}\{#XojoAppName} Resources"
+Name: "{app}\locales"
+Name: "{app}\swiftshader"
+
+; These are the files to include. By default you want to include
+; the EXE plus the Libs and Resources folders
+; but you can include any other files you like as well.
+[Files]
+Source: ".\{#XojoAppName}\{#XojoAppName}.exe"; DestDir: "{app}"; Flags: ignoreversion signonce
+Source: ".\{#XojoAppName}\*"; DestDir: "{app}\"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: ".\{#XojoAppName}\{#XojoAppName} Libs\*"; DestDir: "{app}\{#XojoAppName} Libs"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: ".\{#XojoAppName}\{#XojoAppName} Resources\*"; DestDir: "{app}\{#XojoAppName} Resources"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: ".\{#XojoAppName}\locales\*"; DestDir: "{app}\locales"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: ".\{#XojoAppName}\swiftshader\*"; DestDir: "{app}\swiftshader"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+
+; Creates icons/links in the Start Menu and/or the desktop if the user chooses during installation.
+[Icons]
+;Name: "{group}\{#XojoAppName}"; Filename: "{app}\{#XojoAppName}.exe";
+Name: "{commonprograms}\{#XojoAppName}"; Filename: "{app}\{#XojoAppName}.exe";
+Name: "{commondesktop}\{#XojoAppName}"; Filename: "{app}\{#XojoAppName}.exe"; Tasks: desktopicon;
+
+; Give the user the option to run the app after the installation is finished.
+[Run]
+Filename: "{app}\{#XojoAppName}.exe"; Description: "{cm:LaunchProgram,{#XojoAppName}}"; Flags: nowait postinstall skipifsilent
+
+; This specifies the Visual C++ Windows Runtime Redistributable to also install because
+; it is required by Xojo apps made with 2016r1 or later.
+[Files]
+Source: ".\Windows Universal Runtime\Installers\VC_redist.x64.exe"; DestDir: {tmp}
+
+[Run]
+Filename: {tmp}\VC_redist.x64.exe; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing 64-bit Windows Universal runtime..."; Flags: waituntilterminated; Check: InstallVCRuntime();
+
+[Code]
+// Most of this code is pinched from https://stackoverflow.com/questions/2000296/inno-setup-how-to-automatically-uninstall-previous-installed-version 
+
+function GetUninstallString(): String;
+var
+sUnInstPath: String;
+sUnInstallString: String;
+begin
+sUnInstPath := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\{#emit SetupSetting("AppId")}_is1');
+sUnInstallString := '';
+if not RegQueryStringValue(HKLM, sUnInstPath, 'UninstallString', sUnInstallString) then
+RegQueryStringValue(HKCU, sUnInstPath, 'UninstallString', sUnInstallString);
+Result := sUnInstallString;
+end;
+
+function IsUpgrade(): Boolean;
+begin
+Result := (GetUninstallString() <> '');
+end;
+
+function UnInstallOldVersion(): Integer;
+var
+sUnInstallString: String;
+iResultCode: Integer;
+begin
+// Return Values:
+// 1 - uninstall string is empty
+// 2 - error executing the UnInstallString
+// 3 - successfully executed the UnInstallString
+
+// default return value
+Result := 0;
+
+// get the uninstall string of the old app
+sUnInstallString := GetUninstallString();
+if sUnInstallString <> '' then begin
+sUnInstallString := RemoveQuotes(sUnInstallString);
+if Exec(sUnInstallString, '/SILENT /NORESTART /SUPPRESSMSGBOXES','', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+Result := 3
+else
+Result := 2;
+end else
+Result := 1;
+end;
+
+// Uninstalling old version doesn't seem to be necessary unless app file structure has changed
+// procedure CurStepChanged(CurStep: TSetupStep);
+// begin
+// if (CurStep=ssInstall) then
+// begin
+// if (IsUpgrade()) then
+// begin
+// UnInstallOldVersion();
+// end;
+// end;
+// end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+Result := False;
+
+if ((PageID = wpLicense) or (PageID = wpSelectTasks)) and (IsUpgrade()) then
+begin
+Result := True;
+end;
+end;
+
+// Adapted from https://stackoverflow.com/questions/3618257/is-it-possible-to-accept-custom-command-line-parameters-with-inno-setup 
+{ Check if there is a command-line parameter "kajuupdate=true" }
+function IsKajuUpdate(): Boolean;
+begin
+Result := False;
+if ExpandConstant('{param:kajuupdate|false}') = 'true' then
+Result := True;
+end;
+
+{ If installer is being run by a kaju update then user already has VCRuntime }
+function InstallVCRuntime(): Boolean;
+begin
+Result := not IsKajuUpdate();
+end;
+
+// Adapted from https://stackoverflow.com/questions/28763220/inno-setup-delete-the-installer-after-the-install-process 
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+strContent: String;
+intErrorCode: Integer;
+strSelf_Delete_BAT: String;
+begin
+if (CurStep=ssDone) and (IsKajuUpdate()) then
+begin
+// strContent := ':try_delete' + #13 + #10 +
+// 'del "' + ExpandConstant('{srcexe}') + '"' + #13 + #10 +
+// 'if exist "' + ExpandConstant('{srcexe}') + '" goto try_delete' + #13 + #10 +
+// 'del %0';
+
+strContent := 'for /L %%a in (1,1,100) do (' + #13 + #10 +
+'del "' + ExpandConstant('{srcexe}') + '"' + #13 + #10 +
+'if not exist "' + ExpandConstant('{srcexe}') + '" goto end_loop' + #13 + #10 +
+')' + #13 + #10 +
+':end_loop' + #13 + #10 +
+'del %0';
+strSelf_Delete_BAT := ExtractFilePath(ExpandConstant('{tmp}')) + 'SelfDelete.bat';
+SaveStringToFile(strSelf_Delete_BAT, strContent, False);
+Exec(strSelf_Delete_BAT, '', '', SW_HIDE, ewNoWait, intErrorCode);
+end;
+end;

--- a/Update Test App/App.xojo_code
+++ b/Update Test App/App.xojo_code
@@ -72,6 +72,30 @@ Inherits Application
 	#tag EndMethod
 
 
+	#tag Note, Name = Alterations
+		//MyKajuChanges 0
+		
+		I have made the following alterations to the workflow of Kaju:
+		1. PreCheck is done after the KajuUpdateWindow is shown, rather than before, when it can fail silently and Kaju never check for updates
+		2. For Windows builds only, an InnoSetup installer is registered in the Kau Admin app rather than a zip file
+		3. After the setup.exe is downloaded into a temp folder, when the user presses Quit & Install, it launches the setup.exe
+		
+		I made these changes because:
+		1. I had issues with the PreCheck failing silently (due to xcopy not being available - a problem with my %PATH% system environment variable)
+		2. PreCheck failing because I did not have write permissions to the Application Files folder (must run as administrator)
+		3. The final steps of the normal Kaju workflow were failing when copying files from the decompressed folder
+		"File creation error - The requested operation cannot be performed on a file with a user-mapped section open." ?scanning by Windows Security
+		
+		I think the benefits of these changes are:
+		1. Stops PreCheck from failing silently
+		2. Allows the update to proceed, even if the app has not been run as administrator
+		3. The InnoSetup installer workflow is familiar to most users and can be streamlined to minimise the installation steps
+		4. The same InnoSetup installer can be used for new installations and updates
+		5. The Registry entry for the app in 
+		HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{YourAppID}_is1 is updated with the new version number
+	#tag EndNote
+
+
 	#tag Property, Flags = &h21
 		Private mPrefFolder As FolderItem
 	#tag EndProperty

--- a/Update Test App/Kaju Update Test.xojo_project
+++ b/Update Test App/Kaju Update Test.xojo_project
@@ -1,8 +1,9 @@
 Type=Desktop
-RBProjectVersion=2018.011
+RBProjectVersion=2019.031
 MinIDEVersion=20150400
+OrigIDEVersion=00000000
 Class=App;App.xojo_code;&h00000000503AC7A0;&h0000000000000000;false
-Folder=Custom Plist;Custom Plist;&h0000000031A617FF;&h0000000000000000;false
+Folder=Custom Plist;../Custom Plist;&h0000000031A617FF;&h0000000000000000;false
 Window=WndTest;WndTest.xojo_window;&h000000004308442C;&h0000000000000000;false
 MenuBar=MainMenuBar;MainMenuBar.xojo_menu;&h00000000671CDA54;&h0000000000000000;false
 MultiImage=Some_Image;Some_Image.xojo_image;&h00000000516477FF;&h0000000000000000;false


### PR DESCRIPTION
Hi Kem,

Hopefully, I've done this correctly - this is my first experience with Git!

I have labelled all my changes with MyKajuChanges.

I have made the following alterations to the workflow of Kaju:
1. PreCheck is done after the KajuUpdateWindow is shown, rather than before, when it can fail silently and Kaju never checks for updates
2. For Windows builds only, an InnoSetup installer is registered in the Kau Admin app rather than a zip file
3. After the setup.exe is downloaded into a temp folder, when the user presses Quit & Install, it launches the setup.exe

I made these changes because:
1. I had issues with the PreCheck failing silently (due to xcopy not being available - a problem with my %PATH% system environment variable)
2. PreCheck failing because I did not have write permissions to the Application Files folder (must run as administrator)
3. The final steps of the normal Kaju workflow were failing when copying files from the decompressed folder
"File creation error - The requested operation cannot be performed on a file with a user-mapped section open." ?scanning by Windows Security

I think the benefits of these changes are:
1. Stops PreCheck from failing silently
2. Allows the update to proceed, even if the app has not been run as administrator
3. The InnoSetup installer workflow is familiar to most users and can be streamlined to minimise the installation steps
4. The same InnoSetup installer can be used for new installations and updates
5. The Registry entry for the app in 
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{YourAppID}_is1 is updated with the new version number